### PR TITLE
Adjust keyword argument delegation

### DIFF
--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -53,8 +53,8 @@ module Heroicon
     end
 
     class << self
-      def render(*args)
-        new(*args).render
+      def render(**kwargs)
+        new(**kwargs).render
       end
     end
   end


### PR DESCRIPTION
Due to the [separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), a small change is needed for this Gem to work with Ruby 3.0.

Compatibility with Ruby 2.7(.2) is given from what I could see while testing.

This fixes https://github.com/bharget/heroicon/issues/1