### PR TITLE
feat: allow html attributes in options

### DIFF
--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -15,7 +15,9 @@ module Heroicon
 
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
-      svg["class"] = options[:class] if options[:class].present?
+      options.each do |key, value|
+        svg[key.to_s] = value
+      end
 
       doc
     end


### PR DESCRIPTION
Pretty useful to write stuff like `<%= heroicon "academic-cap", options: { width: "50", height: "50" } %>`