### PR TITLE
feat: set stroke width

### DIFF
--- a/app/helpers/heroicon/application_helper.rb
+++ b/app/helpers/heroicon/application_helper.rb
@@ -2,8 +2,13 @@
 
 module Heroicon
   module ApplicationHelper
-    def heroicon(name, variant: Heroicon.configuration.variant, options: {})
-      raw Heroicon::Icon.render(name: name, variant: variant, options: options)
+    def heroicon(name, variant: Heroicon.configuration.variant, options: {}, path_attributes: {})
+      raw Heroicon::Icon.render(
+        name: name,
+        variant: variant,
+        options: options,
+        path_attributes: path_attributes
+      )
     end
   end
 end

--- a/app/helpers/heroicon/application_helper.rb
+++ b/app/helpers/heroicon/application_helper.rb
@@ -2,12 +2,12 @@
 
 module Heroicon
   module ApplicationHelper
-    def heroicon(name, variant: Heroicon.configuration.variant, options: {}, path_attributes: {})
+    def heroicon(name, variant: Heroicon.configuration.variant, options: {}, path_options: {})
       raw Heroicon::Icon.render(
         name: name,
         variant: variant,
         options: options,
-        path_attributes: path_attributes
+        path_options: path_options
       )
     end
   end

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -4,6 +4,8 @@ module Heroicon
   class Icon
     attr_reader :name, :variant, :options
 
+    EDITABLE_ATTRIBUTES = %w[stroke-width].freeze
+
     def initialize(name:, variant:, options:)
       @name = name
       @variant = safe_variant(variant)
@@ -15,10 +17,14 @@ module Heroicon
 
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
-      stroke_width = options.delete(:stroke_width)
-      svg.css("path[stroke-width]").each do |item|
-        item["stroke-width"] = stroke_width.to_s
-      end if stroke_width
+
+      EDITABLE_ATTRIBUTES.each do |attribute|
+        value = options.delete(attribute.underscore)
+        svg.css("path[#{attribute}]").each do |item|
+          item[attribute] = value.to_s
+        end if value
+      end
+
       options.each do |key, value|
         svg[key.to_s] = value
       end

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -4,12 +4,11 @@ module Heroicon
   class Icon
     attr_reader :name, :variant, :options
 
-    EDITABLE_ATTRIBUTES = %w[stroke-width].freeze
-
-    def initialize(name:, variant:, options:)
+    def initialize(name:, variant:, options:, path_attributes:)
       @name = name
       @variant = safe_variant(variant)
       @options = options
+      @path_attributes = path_attributes
     end
 
     def render
@@ -18,11 +17,11 @@ module Heroicon
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
 
-      EDITABLE_ATTRIBUTES.each do |attribute|
-        value = options.delete(attribute.underscore.to_sym)
+      @path_attributes.each do |key, value|
+        attribute = key.to_s.dasherize
         svg.css("path[#{attribute}]").each do |item|
           item[attribute] = value.to_s
-        end if value
+        end
       end
 
       options.each do |key, value|

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -15,7 +15,9 @@ module Heroicon
 
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
-      svg["class"] = options[:class] if options[:class].present?
+      options.each do |key, value|
+        svg[key.to_s] = value
+      end
 
       doc
     end

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -15,6 +15,10 @@ module Heroicon
 
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
+      stroke_width = options.delete(:stroke_width)
+      svg.css("path[stroke-width]").each do |item|
+        item["stroke-width"] = stroke_width.to_s
+      end if stroke_width
       options.each do |key, value|
         svg[key.to_s] = value
       end

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -19,7 +19,7 @@ module Heroicon
       svg = doc.at_css "svg"
 
       EDITABLE_ATTRIBUTES.each do |attribute|
-        value = options.delete(attribute.underscore)
+        value = options.delete(attribute.underscore.to_sym)
         svg.css("path[#{attribute}]").each do |item|
           item[attribute] = value.to_s
         end if value

--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -4,11 +4,11 @@ module Heroicon
   class Icon
     attr_reader :name, :variant, :options
 
-    def initialize(name:, variant:, options:, path_attributes:)
+    def initialize(name:, variant:, options:, path_options:)
       @name = name
       @variant = safe_variant(variant)
       @options = options
-      @path_attributes = path_attributes
+      @path_options = path_options
     end
 
     def render
@@ -17,7 +17,7 @@ module Heroicon
       doc = Nokogiri::HTML::DocumentFragment.parse(file)
       svg = doc.at_css "svg"
 
-      @path_attributes.each do |key, value|
+      @path_options.each do |key, value|
         attribute = key.to_s.dasherize
         svg.css("path[#{attribute}]").each do |item|
           item[attribute] = value.to_s

--- a/test/dummy/app/views/pages/home.html.erb
+++ b/test/dummy/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
 <%= heroicon "x-circle" %>
 <%= heroicon "x-circle", variant: :outline %>
 <%= heroicon "x-circle", options: { class: "color-red" } %>
-<%= heroicon "x-circle", variant: :outline, path_attributes: { stroke_width: 1 } %>
+<%= heroicon "x-circle", variant: :outline, path_options: { stroke_width: 1 } %>

--- a/test/dummy/app/views/pages/home.html.erb
+++ b/test/dummy/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
 <%= heroicon "x-circle" %>
 <%= heroicon "x-circle", variant: :outline %>
 <%= heroicon "x-circle", options: { class: "color-red" } %>
+<%= heroicon "x-circle", variant: :outline, path_attributes: { stroke_width: 1 } %>


### PR DESCRIPTION
Enables to set the stroke width

Usage:
```erb
<%= heroicon "academic-cap", variant: :outline, options: { stroke_width: "1.5" } %>
```

UPDATE:
New usage:
```erb
<%= heroicon "academic-cap", variant: :outline, path_options: { stroke_width: "1.5" } %>
```