### PR TITLE
Improve example initializer configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ An example configuration looks like this:
 ```ruby
 Heroicon.configure do |config|
   config.variant = :solid
-  config.default_class = {solid: "h-5 w-5", outline: "h-6 w-6", mini: "h-4 w-4"}
+  config.default_class = {solid: "h-6 w-6", outline: "h-6 w-6", mini: "h-5 w-5"}
 end
 ```
 


### PR DESCRIPTION
Using the intended height and width in the example configuration is better since you can copy and paste the config without edits. I stumbled across this one while migrating from v1 to v2.

As per [Heroicons v2 documentation](https://heroicons.com/):

* Outline is designed to be used as 24x24. In Tailwind, this is `h-6 w-6`.
* Solid is designed to be used as 24x24. In Tailwind, this is `h-6 w-6`.
* Mini is designed to be used as 20x20. In Tailwind, this is `h-5 w-5`.