### PR TITLE
CHANGED: Prevent duplicate classes when joined with default_classes

### DIFF
--- a/lib/heroicon/icon.rb
+++ b/lib/heroicon/icon.rb
@@ -48,15 +48,33 @@ module Heroicon
     def prepend_default_class_name
       return if disable_default_class?
 
-      default_class_config = Heroicon.configuration.default_class
+      options[:class] = combine_classes_with_default_class if default_class.present?
+    end
 
-      default_class = if default_class_config.is_a?(String)
+    def combine_classes_with_default_class
+      default_class_list&.concat(additional_class_list)&.uniq&.join(" ")
+    end
+
+    def default_class_list
+      default_class&.blank? ? [] : default_class&.strip&.split&.compact
+    end
+
+    def additional_class_list
+      options[:class].blank? ? [] : options[:class]&.strip&.split&.compact
+    end
+
+    def default_class
+      if default_class_config.is_a?(String)
         default_class_config
       elsif default_class_config.is_a?(Hash)
         default_class_config[variant]
+      else
+        ""
       end
+    end
 
-      options[:class] = "#{default_class} #{options[:class]}".strip if default_class.present?
+    def default_class_config
+      @default_class_config ||= Heroicon.configuration.default_class
     end
 
     def disable_default_class?


### PR DESCRIPTION
When you have initializer setup with a default_class similar to the following

`config.default_class = { solid: 'h-5 w-5', outline: 'h-5 w-5', mini: 'h-4 w-4' }`

And call the helper with `heroicon "icon", options: { class: "h-5 w-5" }`

You are returned with an icon with multiples of the same class (see the screenshot)

<img width="1461" alt="Screenshot 2022-12-10 at 2 50 56 PM" src="https://user-images.githubusercontent.com/5805/206876996-cce2ffe4-3438-48bf-bfcf-e7fadfed93a9.png">

This PR ensures the icons classes and default_classes are merged and all duplicate classes are removed.