### PR TITLE
Make bash commands copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ gem "heroicon"
 And then execute:
 
 ```bash
-$ bundle
+bundle
 ```
 
 Run the installer
 
 ```bash
-$ rails g heroicon:install
+rails g heroicon:install
 ```
 
 ## Usage


### PR DESCRIPTION
They copied with the `$` before which is annoying when trying to set up